### PR TITLE
Added Gradle support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ Thumbs.db
 bin/
 gen/
 .settings/
+
+# Gradle generated files #
+.gradle
+build


### PR DESCRIPTION
ADT 22.0+ and Android Studio uses Gradle as the build system.
